### PR TITLE
Ensure the resolution cookie is set properly

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ const dialog = electron.dialog;
 const path = require('path');
 const url = require('url');
 const app = electron.app;
+const session = electron.session;
 const env = require('./config/env.js');
 const os = require('os');
 const constants = require('./helpers/constants');
@@ -12,6 +13,7 @@ const menubar = require('menubar');
 const Config = require('electron-config');
 const userConfig = new Config();
 const getMenuBarIconPath = require('./helpers/getMenuBarIconPath');
+const RequestFilter = require('./modules/requestFilter');
 
 app.setName(env.appName);
 app.disableHardwareAcceleration();
@@ -47,6 +49,14 @@ let willQuitApp = false;
 function createWindow() {
 	// Create the browser window.
 	mainWindow = new BrowserWindow({ width: 800, height: 600, titleBarStyle: 'hidden-inset' });
+
+	// Propagate retina resolution to requests if necessary
+	const requestFilter = new RequestFilter(session);
+	const display = electron.screen.getPrimaryDisplay();
+	const scaleFactor = display.scaleFactor;
+	if (scaleFactor !== 1.0) {
+		requestFilter.setRetinaCookie(scaleFactor);
+	}
 
 	// and load the index.html of the app.
 	mainWindow.loadURL(

--- a/src/modules/requestFilter.js
+++ b/src/modules/requestFilter.js
@@ -1,0 +1,47 @@
+// This module handles all request filtering
+
+module.exports = function RequestFilter(session) {
+	let retinaCookie = null;
+
+	const filter = {
+		// TODO: Use getURL() or similar here instead?
+		urls: [ 'https://*.facebook.com' ],
+	};
+
+	function ensureRetinaCookie(details) {
+		const delimiter = '; ';
+		const newCookie = `dpr=${retinaCookie}`;
+		const cookieString = details.requestHeaders.Cookie || '';
+		const cookies = cookieString.split(delimiter);
+
+		// Check if the resolution cookie is set, if so, replace it, otherwise append it
+		const wasSet = cookies.reduce((wasSet, cookie, index) => {
+			if (cookie.match(/dpr=/)) {
+				cookies[index] = newCookie;
+				return true;
+			}
+			return wasSet;
+		}, false);
+		if (!wasSet) {
+			cookies.push(newCookie);
+		}
+		details.requestHeaders.Cookie = cookies.join(delimiter);
+	}
+
+	session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
+		if (retinaCookie) {
+			ensureRetinaCookie(details);
+		}
+		const resolve = {
+			cancel: false,
+			requestHeaders: details.requestHeaders,
+		};
+		callback(resolve);
+	});
+
+	return {
+		setRetinaCookie(cookieValue) {
+			retinaCookie = cookieValue;
+		},
+	};
+};


### PR DESCRIPTION
Currently, it seems either Electron doesn't propagate the screen resolution to the webview correctly or Facebook's resolution handling code is buggy. This commit fixes the issue and ensures retina resolution icons are available when necessary.  
Resolves https://github.com/danielbuechele/goofy/issues/352.